### PR TITLE
Update to new helm stable repo

### DIFF
--- a/__fixtures__/v2/with-subchart/requirements.lock
+++ b/__fixtures__/v2/with-subchart/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 0.8.3
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 0.8.3
 digest: sha256:6ab78c0f011b833b1328a5d917c1761b12b17e662c405456f1dad869c1048a9c
 generated: 2018-03-26T15:50:14.210943461+08:00

--- a/__fixtures__/v2/with-subchart/requirements.yaml
+++ b/__fixtures__/v2/with-subchart/requirements.yaml
@@ -1,8 +1,8 @@
 dependencies:
   - name: postgresql
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     version: 0.8.3
   - name: postgresql
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     version: 0.8.3
     alias: another-postgresql

--- a/__fixtures__/v3/with-subchart/Chart.lock
+++ b/__fixtures__/v3/with-subchart/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 0.8.3
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.helm.sh/stable
   version: 0.8.3
 digest: sha256:6ac88461535205e69bafcee4675ba1d353490d3260c4c13c552024e4ca0b7998
 generated: "2020-03-31T17:15:46.7784064+02:00"

--- a/__fixtures__/v3/with-subchart/Chart.yaml
+++ b/__fixtures__/v3/with-subchart/Chart.yaml
@@ -4,9 +4,9 @@ name: with-subchart
 version: 0.1.0
 dependencies:
   - name: postgresql
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     version: 0.8.3
   - name: postgresql
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     version: 0.8.3
     alias: another-postgresql


### PR DESCRIPTION
Switch out deprecated helm repo for new stable repo.

- <https://www.cncf.io/blog/2020/11/05/helm-chart-repository-deprecation-update/>
- <https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository>

Relates to astronomer/issues#2003